### PR TITLE
Use pipenv for package management

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,13 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+hy = "*"
+selenium = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,85 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "30521961e80064f8e98757a58d79f002cc1886bc609786b6a8086de45b6d6d44"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "args": {
+            "hashes": [
+                "sha256:a785b8d837625e9b61c39108532d95b85274acd679693b71ebb5156848fcf814"
+            ],
+            "version": "==0.1.0"
+        },
+        "astor": {
+            "hashes": [
+                "sha256:95c30d87a6c2cf89aa628b87398466840f0ad8652f88eb173125a6df8533fb8d",
+                "sha256:fb503b9e2fdd05609fbf557b916b4a7824171203701660f0c55bbf5a7a68713e"
+            ],
+            "markers": "python_version >= '2.7' and python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*'",
+            "version": "==0.7.1"
+        },
+        "clint": {
+            "hashes": [
+                "sha256:05224c32b1075563d0b16d0015faaf9da43aa214e4a2140e51f08789e7a4c5aa"
+            ],
+            "version": "==0.5.1"
+        },
+        "funcparserlib": {
+            "hashes": [
+                "sha256:b7992eac1a3eb97b3d91faa342bfda0729e990bd8a43774c1592c091e563c91d"
+            ],
+            "version": "==0.3.6"
+        },
+        "hy": {
+            "hashes": [
+                "sha256:4ddd9aa6b1dbe8bcef5f10e87c6d3480a4106f59c30609474555e9e607944d82",
+                "sha256:815eee8b58c3998a29b4316d3fb4011000b40999fdb8d38a0420d71856547f07"
+            ],
+            "index": "pypi",
+            "version": "==0.15.0"
+        },
+        "rply": {
+            "hashes": [
+                "sha256:083edc71214ecaa7f2e3c6e60c11cc1aeb8f99d7a31bafcbd79886b5b7f98137",
+                "sha256:ab443c6c90539ec4d720da3023ab7a5e38e9222c8765a45f759d06df3564dda9"
+            ],
+            "version": "==0.7.6"
+        },
+        "selenium": {
+            "hashes": [
+                "sha256:c53d13a2627d835fee3d1d6291214c62196dfeb6f5f35572bacf31ac60c030c0",
+                "sha256:f9ca21919b564a0a86012cd2177923e3a7f37c4a574207086e710192452a7c40"
+            ],
+            "index": "pypi",
+            "version": "==3.14.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
+                "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
+            ],
+            "markers": "python_version != '3.1.*' and python_version != '3.3.*' and python_version >= '2.6' and python_version != '3.2.*' and python_version < '4' and python_version != '3.0.*'",
+            "version": "==1.23"
+        }
+    },
+    "develop": {}
+}

--- a/README.org
+++ b/README.org
@@ -1,2 +1,25 @@
 * Hylium
 Lighten up your UI automation. Get [[http://docs.hylang.org/en/stable/][Hy]] on Selenium.
+
+A work in progress.
+
+** Getting Started
+*** Virtual Environment
+In order to work on this, we need to set up a virtual environment. This project uses [[https://docs.pipenv.org][pipenv]] to manage packages and virtual environments.
+
+After cloning and navigating to the directory, install the packages, and then setup/use the virtual environment: 
+#+BEGIN_SRC sh
+  pipenv install
+  pipenv shell
+#+END_SRC
+
+*** Install as a library
+To use this as a library, we can install it using =pip=.
+
+After cloning and navigating to the directory, install `hylium` as a package:
+#+BEGIN_SRC sh
+  pip install --user .
+#+END_SRC
+
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-appdirs==1.4.3
-args==0.1.0
-astor==0.6.2
-clint==0.5.1
-hy==0.14.0
-rply==0.7.5
-selenium==3.11.0


### PR DESCRIPTION
## Why?
Switching to `pipenv` instead of `virtualenvwrapper` to manage Python virtual environments. 

`pipenv` is one of recommended tools for this, its easy to work with, and it has nice Emacs integration.

## What
- Replace `requirements.txt` with `Pipfile` and `Pipfile.lock`
- Update README